### PR TITLE
Fix stubgen again

### DIFF
--- a/ngsolve_addon.cmake
+++ b/ngsolve_addon.cmake
@@ -100,20 +100,9 @@ macro(ngsolve_generate_stub_files module_name)
 
   install(CODE ${stubgen_generation_code})
 
-  if(NOT IS_DIRECTORY ${CMAKE_INSTALL_PREFIX}/${stubgen_install_destination})
-    message(
-      FATAL_ERROR
-      "stub files cannot be installed to ${CMAKE_INSTALL_PREFIX}/${stubgen_install_destination}, the folder does not exist."
-    )
-  endif()
-
-  if(EXISTS ${stubgen_file})
-    install(FILES ${stubgen_file} DESTINATION ${stubgen_install_destination})
-  elseif(IS_DIRECTORY ${stubgen_directory})
-    install(DIRECTORY ${stubgen_directory} DESTINATION ${stubgen_install_destination})
-  else()
-    message(FATAL_ERROR "Unable to locate and install stub files.")
-  endif()
+  # sometimes, stubgen will only generate one file, and sometimes a whole folder. Try both.
+  install(FILES ${stubgen_file} DESTINATION ${stubgen_install_destination} OPTIONAL)
+  install(DIRECTORY ${stubgen_directory} DESTINATION ${stubgen_install_destination} OPTIONAL)
 endmacro()
 
 message(STATUS "Install dir: ${CMAKE_INSTALL_PREFIX}")


### PR DESCRIPTION
Hey @mhochsteger, sorry to open another PR on the same topic again. My previous PR had a subtle bug, that I did not catch in my testing:
The conditions `if(EXISTS ${stubgen_file})` and `elseif(IS_DIRECTORY ${stubgen_directory})` are not evaluated at `make install` time, but rather at cmake Makefile generation. That is problematic, e.g. when stubgen has not run before and neither a stub folder nor a stub file exists upon cmake generation.
Therefore, I have removed these checks, and rather made the installs `OPTIONAL`. Of course, there will not be an error message, if both installs fail, but I think it still is a good compromise.